### PR TITLE
Limit maven build execution

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,16 @@
 name: Maven Build
 
-on: [push]
+on:
+  push:
+    paths: 
+      - '.mvn/wrapper/**'
+      - 'pom.xml'
+      - 'src/**'    
+  pull_request:
+    paths: 
+      - '.mvn/wrapper/**'
+      - 'pom.xml'
+      - 'src/**'
 
 jobs:
   build:


### PR DESCRIPTION
Maven Action execution should only be executed when build related paths have changes.

Closes gh-31.