### PR TITLE
Change Dependabot merging strategy

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,4 +12,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
+          command: squash and merge
           github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE }}


### PR DESCRIPTION
Default merging strategy, merge, will create merge commit message, which may look not so pretty.

This commit will request Dependabot to squash all commits into one before merging the branch into master.

Closes gh-33.